### PR TITLE
댓글/대댓글 기능 추가

### DIFF
--- a/src/main/java/com/be/inssagram/common/BaseEntity.java
+++ b/src/main/java/com/be/inssagram/common/BaseEntity.java
@@ -1,0 +1,40 @@
+package com.be.inssagram.common;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Setter
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private String createdAt;
+
+    @LastModifiedDate
+    private String updatedAt;
+
+    private String deletedAt;
+
+    @PrePersist
+    public void onPrePersist() {
+        createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"));
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void onPreUpdate() {
+        updatedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"));
+    }
+
+}

--- a/src/main/java/com/be/inssagram/config/security/SecurityConfig.java
+++ b/src/main/java/com/be/inssagram/config/security/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(authorize -> {
             try {
                 authorize
-                        .requestMatchers("/*","member/update/*") // 해당 경로는 인증 없이 접근 가능
+                        .requestMatchers("/**","member/update/*") // 해당 경로는 인증 없이 접근 가능
                         .permitAll();
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/src/main/java/com/be/inssagram/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/be/inssagram/domain/comment/controller/CommentController.java
@@ -1,0 +1,66 @@
+package com.be.inssagram.domain.comment.controller;
+
+import com.be.inssagram.common.ApiResponse;
+import com.be.inssagram.domain.comment.dto.request.CommentRequest;
+import com.be.inssagram.domain.comment.dto.response.CommentInfoResponse;
+import com.be.inssagram.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping("/create")
+    public ApiResponse<CommentInfoResponse> createComment(
+            @RequestParam(value = "post-id") Long postId,
+            @RequestBody CommentRequest request) {
+        return ApiResponse.createSuccess(
+                commentService.createComment(postId, request));
+    }
+
+    @PostMapping("/create/reply")
+    public ApiResponse<CommentInfoResponse> createReply(
+            @RequestParam(value = "parent-comment-id") Long parentCommentId,
+            @RequestBody CommentRequest request) {
+        return ApiResponse.createSuccess(
+                commentService.createReply(parentCommentId, request));
+    }
+
+    @PutMapping("/update/{id}")
+    public ApiResponse<CommentInfoResponse> updateComment(
+            @PathVariable Long id, @RequestBody CommentRequest request) {
+        return ApiResponse.createSuccessWithMessage(
+                commentService.updateComment(id, request), "수정됨");
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ApiResponse<Object> deleteComment(
+            @PathVariable Long id) {
+        commentService.deletePost(id);
+        return ApiResponse.createMessage("삭제 완료");
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<List<CommentInfoResponse>> searchParentComments(
+            @RequestParam(value = "post-id") Long postId
+    ) {
+        return ApiResponse.createSuccess(
+                commentService.searchParentComments(postId));
+    }
+
+    @GetMapping("/search/reply")
+    public ApiResponse<List<CommentInfoResponse>> searchReplyByParentComment(
+            @RequestParam(value = "parent-comment-id") Long parentCommentId
+    ) {
+        return ApiResponse.createSuccess(
+                commentService.searchReplyByParentComment(parentCommentId));
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/be/inssagram/domain/comment/dto/request/CommentRequest.java
@@ -1,0 +1,15 @@
+package com.be.inssagram.domain.comment.dto.request;
+
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentRequest {
+    private Long memberId;
+    private String contents;
+
+}

--- a/src/main/java/com/be/inssagram/domain/comment/dto/response/CommentInfoResponse.java
+++ b/src/main/java/com/be/inssagram/domain/comment/dto/response/CommentInfoResponse.java
@@ -1,0 +1,45 @@
+package com.be.inssagram.domain.comment.dto.response;
+
+import com.be.inssagram.domain.comment.entity.Comment;
+import lombok.*;
+
+import java.util.List;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentInfoResponse {
+
+    private Long commentId;
+    private Long postId;
+    private Long memberId;
+    private String content;
+    private List<Comment> childComments;
+    private boolean replyFlag;
+
+    public CommentInfoResponse(Long commentId, Long postId, Long memberId,
+                               String content, boolean replyFlag) {
+        this.commentId = commentId;
+        this.postId = postId;
+        this.memberId = memberId;
+        this.content = content;
+        this.replyFlag = replyFlag;
+    }
+
+    public static CommentInfoResponse from(Comment comment) {
+
+        return CommentInfoResponse.builder()
+                .commentId(comment.getId())
+                .postId(comment.getPost().getId())
+                .memberId(comment.getMember().getId())
+                .content(comment.getContent())
+                .childComments(comment.getChildComments())
+                .replyFlag(comment.isReplyFlag())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/comment/entity/Comment.java
+++ b/src/main/java/com/be/inssagram/domain/comment/entity/Comment.java
@@ -1,0 +1,57 @@
+package com.be.inssagram.domain.comment.entity;
+
+import com.be.inssagram.common.BaseEntity;
+import com.be.inssagram.domain.comment.dto.request.CommentRequest;
+import com.be.inssagram.domain.member.entity.Member;
+import com.be.inssagram.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@SQLDelete(sql = "UPDATE inssagram.comment SET deleted_at = current_timestamp WHERE comment_id = ?")
+@Where(clause = "deleted_at is NULL")
+@Entity(name = "COMMENT")
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "COMMENT_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 댓글은 하나의 Post에 속합니다.
+//    @JsonBackReference
+    private Post post;
+//    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+//    private Long memberId;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 대댓글의 부모 댓글
+    @JoinColumn
+    private Comment parentComment; // 부모 댓글
+
+    // 대댓글을 작성할 수 있는 필드
+    @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+    private List<Comment> childComments = new ArrayList<>();
+
+    // 댓글과 대댓글을 구분하기 위한 필드
+    private boolean replyFlag;
+
+    public void updateFields(CommentRequest request) {
+        if (request.getContents() != null) {
+            content = request.getContents();
+        }
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/be/inssagram/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,34 @@
+package com.be.inssagram.domain.comment.repository;
+
+import com.be.inssagram.domain.comment.dto.response.CommentInfoResponse;
+import com.be.inssagram.domain.comment.entity.Comment;
+import com.be.inssagram.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 한 포스트에서 부모 댓글 들만 조회
+        // 오래 발생
+    @Query("SELECT c FROM COMMENT c WHERE c.post = :post AND c.replyFlag = false order by c.id asc")
+    List<Comment> findParentCommentsByPost(@Param("post") Post post);
+        // 오류 해결 및 쿼리 개수 감소.
+    @Query("SELECT NEW com.be.inssagram.domain.comment.dto.response.CommentInfoResponse(" +
+            "c.id, c.post.id, c.member.id, c.content, c.replyFlag) " +
+            "FROM COMMENT c WHERE c.post = :post AND c.replyFlag = false ORDER BY c.id ASC")
+    List<CommentInfoResponse> findParentCommentsByPostAndIsReply(@Param("post") Post post);
+    List<Comment> findByPostAndReplyFlagIsFalse(Post post);
+
+    // 한 부모 댓글의 대댓글 조회
+    @Query("SELECT NEW com.be.inssagram.domain.comment.dto.response.CommentInfoResponse(" +
+            "c.id, c.post.id, c.member.id, c.content, c.replyFlag) " +
+            "FROM COMMENT c WHERE c.parentComment = :parentComment")
+    List<CommentInfoResponse> findRepliesByParentComment(@Param("parentComment") Comment parentComment);
+    List<Comment> findByParentComment(Comment parentComment);
+}

--- a/src/main/java/com/be/inssagram/domain/comment/service/CommentService.java
+++ b/src/main/java/com/be/inssagram/domain/comment/service/CommentService.java
@@ -1,0 +1,131 @@
+package com.be.inssagram.domain.comment.service;
+
+import com.be.inssagram.domain.comment.dto.request.CommentRequest;
+import com.be.inssagram.domain.comment.dto.response.CommentInfoResponse;
+import com.be.inssagram.domain.comment.entity.Comment;
+import com.be.inssagram.domain.comment.repository.CommentRepository;
+import com.be.inssagram.domain.member.entity.Member;
+import com.be.inssagram.domain.member.repository.MemberRepository;
+import com.be.inssagram.domain.post.entity.Post;
+import com.be.inssagram.domain.post.repository.PostRepository;
+import com.be.inssagram.exception.comment.CannotCreateCommentException;
+import com.be.inssagram.exception.comment.CommentDoesNotExistException;
+import com.be.inssagram.exception.member.UserDoesNotExistException;
+import com.be.inssagram.exception.member.UserNotMatchException;
+import com.be.inssagram.exception.post.PostDoesNotExistException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public CommentInfoResponse createComment(
+            Long postId, CommentRequest request) {
+        // 유저(Member)를 찾아옵니다.
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(UserDoesNotExistException::new);
+
+        // 게시물(Post)을 찾아옵니다.
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostDoesNotExistException::new);
+
+        // 댓글(Comment) 객체를 생성합니다.
+        Comment comment = Comment.builder()
+                .post(post)
+                .member(member)
+                .content(request.getContents())
+                .build();
+
+        // 댓글을 저장합니다.
+        return CommentInfoResponse.from(commentRepository.save(comment));
+    }
+
+    public CommentInfoResponse createReply(
+            Long parentCommentId, CommentRequest request) {
+        // 유저(Member)를 찾아옵니다.
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(UserDoesNotExistException::new);
+
+        // 부모 댓글을 찾아옵니다.
+        Comment parentComment = commentRepository.findById(parentCommentId)
+                .orElseThrow(CommentDoesNotExistException::new);
+
+        // isReply 값 확인
+        if (parentComment.isReplyFlag()) {
+            throw new CannotCreateCommentException();
+        }
+
+        // 대댓글을 생성합니다.
+        Comment reply = Comment.builder()
+                .post(parentComment.getPost())
+                .member(member)
+                .content(request.getContents())
+                .parentComment(parentComment)
+                .replyFlag(true)
+                .build();
+        Comment savedReply = commentRepository.save(reply);
+        parentComment.getChildComments().add(reply);
+        commentRepository.save(parentComment);
+        // 대댓글을 저장합니다.
+        return CommentInfoResponse.from(savedReply);
+    }
+
+    public CommentInfoResponse updateComment(
+            Long commentId, CommentRequest request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentDoesNotExistException::new);
+
+        if (!Objects.equals(comment.getMember().getId(), request.getMemberId())) {
+            throw new UserNotMatchException();
+        }
+
+        comment.updateFields(request);
+        commentRepository.save(comment);
+        return CommentInfoResponse.from(comment);
+    }
+
+    public void deletePost(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentDoesNotExistException::new);
+        commentRepository.save(comment);
+        commentRepository.delete(comment);
+    }
+
+    public List<CommentInfoResponse> searchParentComments(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostDoesNotExistException::new);
+//        return commentRepository.findParentCommentsByPost(post).stream()
+//                .map(CommentInfoResponse::from).toList();
+        return commentRepository.findParentCommentsByPostAndIsReply(post);
+    }
+
+    public List<CommentInfoResponse> searchComments(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostDoesNotExistException::new);
+        return commentRepository.findByPostAndReplyFlagIsFalse(post).stream()
+                .map(CommentInfoResponse::from).toList();
+    }
+
+    public List<CommentInfoResponse> searchReplyByParentComment(Long parentCommentId) {
+        Comment comment = commentRepository.findById(parentCommentId)
+                .orElseThrow(CommentDoesNotExistException::new);
+        return commentRepository.findRepliesByParentComment(comment);
+    }
+
+    public List<CommentInfoResponse> searchReply (Long parentCommentId) {
+        Comment comment = commentRepository.findById(parentCommentId)
+                .orElseThrow(CommentDoesNotExistException::new);
+
+        return commentRepository.findByParentComment(comment).stream().map(CommentInfoResponse::from).toList();
+    }
+
+}
+

--- a/src/main/java/com/be/inssagram/domain/post/controller/PostController.java
+++ b/src/main/java/com/be/inssagram/domain/post/controller/PostController.java
@@ -1,0 +1,58 @@
+package com.be.inssagram.domain.post.controller;
+
+
+import com.be.inssagram.common.ApiResponse;
+import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
+import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
+import com.be.inssagram.domain.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/post")
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping("/create")
+    public ApiResponse<PostInfoResponse> createPost(
+            @Valid @RequestBody CreatePostRequest request) {
+        PostInfoResponse response = postService.createPost(request);
+        return ApiResponse.createSuccessWithMessage(response ,"완료");
+    }
+
+    @PutMapping("/update/{id}")
+    public ApiResponse<PostInfoResponse> updatePost(
+            @PathVariable Long id, @RequestBody UpdatePostRequest request) {
+        return ApiResponse.createSuccess(postService.updatePost(id, request));
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ApiResponse<Object> deletePost(
+            @PathVariable Long id) {
+        postService.deletePost(id);
+        return ApiResponse.createMessage("삭제 완료");
+    }
+
+    @GetMapping("/{id}/detail")
+    public ApiResponse<PostInfoResponse> searchPostDetail(
+            @PathVariable Long id) {
+        return ApiResponse.createSuccess(postService.searchPostDetail(id));
+    }
+
+    @GetMapping("/all")
+    public ApiResponse<Page<PostInfoResponse>> searchPostAll(
+            @PageableDefault(size = 10, sort = "createdAt"
+                    , direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.createSuccess(postService.searchPostAll(pageable));
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/request/CreatePostRequest.java
@@ -1,0 +1,24 @@
+package com.be.inssagram.domain.post.dto.request;
+
+import lombok.*;
+
+import java.util.List;
+import java.util.Set;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreatePostRequest {
+    private Long memberId;
+    private List<String> image;
+    private String contents;
+    private String location;
+//    private Set<Long> taggedMemberIds; // TaggedMember 엔티티의 ID 목록
+    private Set<String> taggedMembers; // TaggedMember 목록
+//    private Set<Long> hashTagIds; // HashTag 엔티티의 ID 목록
+    private Set<String> hashTags; // HashTag 목록
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/request/UpdatePostRequest.java
@@ -1,0 +1,20 @@
+package com.be.inssagram.domain.post.dto.request;
+
+
+import lombok.*;
+
+import java.util.Set;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdatePostRequest {
+    private String contents;
+    private String location;
+    private Set<String> taggedMembers;
+    private Set<String> hashTags;
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
@@ -1,8 +1,10 @@
 package com.be.inssagram.domain.post.dto.response;
 
+import com.be.inssagram.domain.comment.entity.Comment;
 import com.be.inssagram.domain.post.entity.Post;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -19,10 +21,16 @@ public class PostInfoResponse {
     private String contents;
     private String location;
     private Integer likeCount;
+//    private List<Comment> comments;
+    private Integer commentsCounts;
     private Set<String> taggedMembers;
     private Set<String> hashTags;
 
     public static PostInfoResponse from(Post post) {
+        int commentCounts = 0;
+        if (post.getComments() != null) {
+            commentCounts = post.getComments().size();
+        }
         return PostInfoResponse.builder()
                 .postId(post.getId())
                 .memberId(post.getMemberId())
@@ -30,6 +38,8 @@ public class PostInfoResponse {
                 .contents(post.getContents())
                 .location(post.getLocation())
                 .likeCount(post.getLikeCount())
+//                .comments(post.getComments())
+                .commentsCounts(commentCounts)
                 .taggedMembers(post.getTaggedMembers())
                 .hashTags(post.getHashTags())
                 .build();

--- a/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
@@ -1,0 +1,38 @@
+package com.be.inssagram.domain.post.dto.response;
+
+import com.be.inssagram.domain.post.entity.Post;
+import lombok.*;
+
+import java.util.List;
+import java.util.Set;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostInfoResponse {
+    private Long postId;
+    private Long memberId;
+    private List<String> image;
+    private String contents;
+    private String location;
+    private Integer likeCount;
+    private Set<String> taggedMembers;
+    private Set<String> hashTags;
+
+    public static PostInfoResponse from(Post post) {
+        return PostInfoResponse.builder()
+                .postId(post.getId())
+                .memberId(post.getMemberId())
+                .image(post.getImage())
+                .contents(post.getContents())
+                .location(post.getLocation())
+                .likeCount(post.getLikeCount())
+                .taggedMembers(post.getTaggedMembers())
+                .hashTags(post.getHashTags())
+                .build();
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/entity/Post.java
+++ b/src/main/java/com/be/inssagram/domain/post/entity/Post.java
@@ -1,12 +1,15 @@
 package com.be.inssagram.domain.post.entity;
 
 import com.be.inssagram.common.BaseEntity;
+import com.be.inssagram.domain.comment.entity.Comment;
 import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -33,8 +36,10 @@ public class Post extends BaseEntity {
     @ElementCollection
     private List<String> likedByPerson;
     private Integer likeCount;
-    @ElementCollection
-    private List<String> comments;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+//    @JsonManagedReference
+    private List<Comment> comments = new ArrayList<>();
     @ElementCollection
     private Set<String> taggedMembers;
     @ElementCollection

--- a/src/main/java/com/be/inssagram/domain/post/entity/Post.java
+++ b/src/main/java/com/be/inssagram/domain/post/entity/Post.java
@@ -1,0 +1,67 @@
+package com.be.inssagram.domain.post.entity;
+
+import com.be.inssagram.common.BaseEntity;
+import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.util.List;
+import java.util.Set;
+
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@SQLDelete(sql = "UPDATE inssagram.post SET deleted_at = current_timestamp WHERE post_id = ?")
+@Where(clause = "deleted_at is NULL")
+@Entity(name = "POST")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "POST_ID")
+    private Long id;
+    private Long memberId;
+    @ElementCollection
+    private List<String> image;
+    private String contents;
+    private String location;
+    @ElementCollection
+    private List<String> likedByPerson;
+    private Integer likeCount;
+    @ElementCollection
+    private List<String> comments;
+    @ElementCollection
+    private Set<String> taggedMembers;
+    @ElementCollection
+    private Set<String> hashTags;
+
+
+    public void setTaggedMembers(Set taggedMembers) {
+        this.taggedMembers = taggedMembers;
+    }
+
+    public void setHashTags(Set hashTags) {
+        this.hashTags = hashTags;
+    }
+
+    public void updateFields(UpdatePostRequest request) {
+        if (request.getLocation() != null) {
+            location = request.getLocation();
+        }
+        if (request.getContents() != null) {
+            contents = request.getContents();
+        }
+        if (request.getTaggedMembers() != null) {
+            taggedMembers = request.getTaggedMembers();
+        }
+        if (request.getHashTags() != null) {
+            hashTags = request.getHashTags();
+        }
+    }
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/be/inssagram/domain/post/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.be.inssagram.domain.post.repository;
+
+import com.be.inssagram.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/service/PostService.java
+++ b/src/main/java/com/be/inssagram/domain/post/service/PostService.java
@@ -1,0 +1,74 @@
+package com.be.inssagram.domain.post.service;
+
+import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
+import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
+import com.be.inssagram.domain.post.entity.Post;
+import com.be.inssagram.domain.post.repository.PostRepository;
+import com.be.inssagram.exception.post.PostDoesNotExistException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public PostInfoResponse createPost(CreatePostRequest request) {
+
+        Post post = Post.builder()
+                .memberId(request.getMemberId())
+                .image(request.getImage())
+                .contents(request.getContents())
+                .location(request.getLocation())
+                .build();
+
+        Set<String> taggedMembers = new HashSet<>();
+        Set<String> hashTags = new HashSet<>();
+
+
+        post.setTaggedMembers(taggedMembers);
+        post.setHashTags(hashTags);
+
+        return PostInfoResponse.from(postRepository.save(post));
+    }
+
+    public PostInfoResponse updatePost(Long postId, UpdatePostRequest request) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                PostDoesNotExistException::new);
+        post.updateFields(request);
+        postRepository.save(post);
+        return PostInfoResponse.from(post);
+    }
+
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                PostDoesNotExistException::new);
+        postRepository.save(post);  // 테스트 코드에서 확인 위한 작업.
+        postRepository.delete(post);
+    }
+
+    public PostInfoResponse searchPostDetail(Long postId) {
+        return postRepository.findById(postId)
+                .map(PostInfoResponse::from)
+                .orElseThrow(PostDoesNotExistException::new);
+    }
+
+    public Page<PostInfoResponse> searchPostAll(Pageable pageable) {
+        try {
+            return postRepository.findAll(pageable).map(PostInfoResponse::from);
+        } catch (Exception e) {
+            // 예외 처리: findAll 메서드에서 예외가 발생하면 빈 Page 객체를 반환
+            return new PageImpl<>(Collections.emptyList());
+        }
+    }
+
+}

--- a/src/main/java/com/be/inssagram/exception/comment/CannotCreateCommentException.java
+++ b/src/main/java/com/be/inssagram/exception/comment/CannotCreateCommentException.java
@@ -1,0 +1,9 @@
+package com.be.inssagram.exception.comment;
+
+import static com.be.inssagram.exception.errorCode.ErrorCode.IMPOSSIBLE_CREATE_COMMENT;
+
+public class CannotCreateCommentException extends IllegalArgumentException {
+    public CannotCreateCommentException() {
+        super(IMPOSSIBLE_CREATE_COMMENT.getDescription());
+    }
+}

--- a/src/main/java/com/be/inssagram/exception/comment/CommentDoesNotExistException.java
+++ b/src/main/java/com/be/inssagram/exception/comment/CommentDoesNotExistException.java
@@ -1,0 +1,9 @@
+package com.be.inssagram.exception.comment;
+
+import static com.be.inssagram.exception.errorCode.ErrorCode.COMMENT_NOT_FOUND;
+
+public class CommentDoesNotExistException extends RuntimeException {
+    public CommentDoesNotExistException() {
+        super(COMMENT_NOT_FOUND.getDescription());
+    }
+}

--- a/src/main/java/com/be/inssagram/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/be/inssagram/exception/errorCode/ErrorCode.java
@@ -6,8 +6,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    // member error code
+    USER_NOT_MATCH("유저가 일치하지 않습니다. 유저정보를 확인해주세요."),
+
     // Post Error Code
-    POST_NOT_FOUND("존재하지 않는 게시글 입니다.")
+    POST_NOT_FOUND("존재하지 않는 게시글 입니다."),
+
+    // Comment Error Code
+    COMMENT_NOT_FOUND("존재하지 않는 댓글입니다."),
+    IMPOSSIBLE_CREATE_COMMENT("더이상 댓글을 달 수 없습니다.")
+
 
     ;
     private final String description;

--- a/src/main/java/com/be/inssagram/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/be/inssagram/exception/errorCode/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.be.inssagram.exception.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // Post Error Code
+    POST_NOT_FOUND("존재하지 않는 게시글 입니다.")
+
+    ;
+    private final String description;
+}

--- a/src/main/java/com/be/inssagram/exception/handler/CommentExceptionHandler.java
+++ b/src/main/java/com/be/inssagram/exception/handler/CommentExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.be.inssagram.exception.handler;
+
+import com.be.inssagram.common.ApiResponse;
+import com.be.inssagram.exception.comment.CannotCreateCommentException;
+import com.be.inssagram.exception.comment.CommentDoesNotExistException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommentExceptionHandler {
+
+    // 댓글 조회시 없는 댓글일 때
+    @ExceptionHandler(CommentDoesNotExistException.class)
+    public ResponseEntity<ApiResponse<?>> handleCommentDoesNotExistException(
+            RuntimeException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.createError(exception.getMessage()));
+    }
+
+    // 더이상 댓글을 달 수 없을 때
+    @ExceptionHandler(CannotCreateCommentException.class)
+    public ResponseEntity<ApiResponse<?>> handleCannotCreateCommentException(
+            IllegalArgumentException exception) {
+        return ResponseEntity.status(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS)
+                .body(ApiResponse.createError(exception.getMessage()));
+    }
+
+
+}

--- a/src/main/java/com/be/inssagram/exception/handler/PostExceptionHandler.java
+++ b/src/main/java/com/be/inssagram/exception/handler/PostExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.be.inssagram.exception.handler;
+
+import com.be.inssagram.common.ApiResponse;
+import com.be.inssagram.exception.post.PostDoesNotExistException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class PostExceptionHandler {
+
+    //포스트 조회시 없는 포스트일 때
+    @ExceptionHandler(PostDoesNotExistException.class)
+    public ResponseEntity<ApiResponse<?>> handlePostDoesNotExistException(
+            RuntimeException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.createError(exception.getMessage()));
+    }
+}

--- a/src/main/java/com/be/inssagram/exception/member/UserNotMatchException.java
+++ b/src/main/java/com/be/inssagram/exception/member/UserNotMatchException.java
@@ -1,0 +1,9 @@
+package com.be.inssagram.exception.member;
+
+import static com.be.inssagram.exception.errorCode.ErrorCode.USER_NOT_MATCH;
+
+public class UserNotMatchException extends RuntimeException{
+    public UserNotMatchException()  {
+        super(USER_NOT_MATCH.getDescription());
+    }
+}

--- a/src/main/java/com/be/inssagram/exception/post/PostDoesNotExistException.java
+++ b/src/main/java/com/be/inssagram/exception/post/PostDoesNotExistException.java
@@ -1,0 +1,9 @@
+package com.be.inssagram.exception.post;
+
+import static com.be.inssagram.exception.errorCode.ErrorCode.POST_NOT_FOUND;
+
+public class PostDoesNotExistException extends RuntimeException {
+    public PostDoesNotExistException() {
+        super(POST_NOT_FOUND.getDescription());
+    }
+}

--- a/src/test/java/com/be/inssagram/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/be/inssagram/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,186 @@
+package com.be.inssagram.domain.post.controller;
+
+import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
+import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
+import com.be.inssagram.domain.post.service.PostService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = PostController.class, excludeFilters = {})
+class PostControllerTest {
+    @MockBean
+    private PostService postService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser()
+    void successCreatePost() throws Exception {
+        //given
+        given(postService.createPost(any())).willReturn(PostInfoResponse
+                .builder()
+                .postId(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .likeCount(1)
+                .location("home")
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build());
+        //when
+        //then
+        mockMvc.perform(post("/post/create")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .content(objectMapper.writeValueAsString(
+                                CreatePostRequest.builder()
+                                        .memberId(2L)
+                                        .image(new ArrayList<>())
+                                        .contents("AAA")
+                                        .location("sweet")
+                                        .taggedMembers(new HashSet<>())
+                                        .hashTags(new HashSet<>())
+                                        .build()))
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").value(1))
+        ;
+    }
+
+    @Test
+    @WithMockUser()
+    void successUpdatePost() throws Exception {
+        //given
+        given(postService.updatePost(anyLong(), any()))
+                .willReturn(PostInfoResponse.builder()
+                        .postId(1L)
+                        .memberId(1L)
+                        .image(new ArrayList<>())
+                        .contents("contents")
+                        .likeCount(1)
+                        .location("home")
+                        .taggedMembers(new HashSet<>())
+                        .hashTags(new HashSet<>())
+                        .build());
+        //when
+        //then
+        mockMvc.perform(put("/post/update/1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .content(objectMapper.writeValueAsString(UpdatePostRequest
+                                .builder()
+                                .contents("AAA")
+                                .location("sweet")
+                                .taggedMembers(new HashSet<>())
+                                .hashTags(new HashSet<>())
+                                .build()))
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status")
+                        .value("success"))
+                .andExpect(jsonPath("$.data.contents")
+                        .value("contents"))
+        ;
+    }
+
+    @Test
+    @WithMockUser()
+    void successDeletePost() throws Exception {
+        //given
+        Long postID = 1L;
+        //when
+        //then
+        mockMvc.perform(delete("/post/delete/{postId}", postID)
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockUser()
+    void successSearchPost_detail() throws Exception {
+        //given
+        given(postService.searchPostDetail(anyLong()))
+                .willReturn(PostInfoResponse.builder()
+                        .postId(1L)
+                        .memberId(1L)
+                        .image(new ArrayList<>())
+                        .contents("contents")
+                        .likeCount(1)
+                        .location("home")
+                        .taggedMembers(new HashSet<>())
+                        .hashTags(new HashSet<>())
+                        .build());
+        //when
+        //then
+        mockMvc.perform(get("/post/{postId}/detail", 1L)
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.status")
+                        .value("success"))
+                .andExpect(jsonPath("$.data.contents")
+                        .value("contents"))
+        ;
+    }
+
+    @Test
+    @WithMockUser()
+    void successSearchPost_all() throws Exception {
+        //given
+        List<PostInfoResponse> postInfoResponseList =
+                Arrays.asList(PostInfoResponse.builder()
+                        .postId(1L)
+                        .memberId(1L)
+                        .image(new ArrayList<>())
+                        .contents("contents")
+                        .likeCount(1)
+                        .location("home")
+                        .taggedMembers(new HashSet<>())
+                        .hashTags(new HashSet<>())
+                        .build());
+        Page<PostInfoResponse> page = new PageImpl<>(postInfoResponseList);
+        given(postService.searchPostAll(any()))
+                .willReturn(page);
+        //when
+        //then
+        mockMvc.perform(get("/post/all")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.status")
+                        .value("success"))
+                .andExpect(jsonPath("$.data.content[0].memberId")
+                        .value(1L))
+        ;
+    }
+}

--- a/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
@@ -1,0 +1,210 @@
+package com.be.inssagram.domain.post.service;
+
+import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
+import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
+import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
+import com.be.inssagram.domain.post.entity.Post;
+import com.be.inssagram.domain.post.repository.PostRepository;
+import com.be.inssagram.exception.post.PostDoesNotExistException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    @Test
+    void successCreatePost() {
+        //given
+        Post post = Post.builder()
+                .id(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .location("home")
+                .likedByPerson(new ArrayList<>())
+                .likeCount(34)
+                .comments(new ArrayList<>())
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build();
+        given(postRepository.save(any())).willReturn(post);
+        //when
+        PostInfoResponse createResponse = postService.createPost(CreatePostRequest
+                .builder()
+                .memberId(2L)
+                .image(new ArrayList<>())
+                .contents("AAA")
+                .location("sweet")
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build());
+        //then
+        assertEquals(1L, createResponse.getMemberId());
+    }
+
+    @Test
+    void successUpdatePost() {
+        //given
+        Post post = Post.builder()
+                .id(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .location("home")
+                .likedByPerson(new ArrayList<>())
+                .likeCount(34)
+                .comments(new ArrayList<>())
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build();
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        //when
+        PostInfoResponse updateResponse = postService.updatePost(1L, UpdatePostRequest
+                .builder()
+                .contents("AAA")
+                .location("sweet")
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build());
+        //then
+        assertEquals(1L, updateResponse.getMemberId());
+        assertEquals("AAA", updateResponse.getContents());
+    }
+
+    @Test
+    void successDeletePost() {
+        //given
+        Post post = Post.builder()
+                .id(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .location("home")
+                .likedByPerson(new ArrayList<>())
+                .likeCount(34)
+                .comments(new ArrayList<>())
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build();
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+        //when
+        postService.deletePost(1L);
+        //then
+        verify(postRepository, times(1)).save(captor.capture());
+        assertEquals(1, captor.getValue().getId());
+    }
+
+    @Test
+    void successSearchPost_detail() {
+        //given
+        Post post = Post.builder()
+                .id(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .location("home")
+                .likedByPerson(new ArrayList<>())
+                .likeCount(34)
+                .comments(new ArrayList<>())
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build();
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        //when
+        PostInfoResponse searchResponse = postService.searchPostDetail(1L);
+        //then
+        assertEquals(1L, searchResponse.getMemberId());
+    }
+
+    @Test
+    void successSearchPost_all() {
+        //given
+        Post post = Post.builder()
+                .id(1L)
+                .memberId(1L)
+                .image(new ArrayList<>())
+                .contents("contents")
+                .location("home")
+                .likedByPerson(new ArrayList<>())
+                .likeCount(34)
+                .comments(new ArrayList<>())
+                .taggedMembers(new HashSet<>())
+                .hashTags(new HashSet<>())
+                .build();
+        List<Post> list = Collections.singletonList(post);
+        Page<Post> page = new PageImpl<>(list);
+        given(postRepository.findAll((Pageable) any())).willReturn(page);
+        //when
+        Pageable pageable = PageRequest.of(0, 3);
+        Page<PostInfoResponse> responses = postService.searchPostAll(pageable);
+        //then
+        assertEquals(1L, responses.getContent().get(0).getPostId());
+    }
+
+    @Test
+    void failedUpdatePost() {
+        //given
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(PostDoesNotExistException.class,
+                () -> postService.updatePost(1L, UpdatePostRequest
+                        .builder()
+                        .contents("AAA")
+                        .location("sweet")
+                        .taggedMembers(new HashSet<>())
+                        .hashTags(new HashSet<>())
+                        .build()));
+        //then
+        assertEquals("존재하지 않는 게시글 입니다.", exception.getMessage());
+    }
+
+    @Test
+    void failedDeletePost() {
+        //given
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(PostDoesNotExistException.class,
+                () -> postService.deletePost(1L));
+        //then
+        assertEquals("존재하지 않는 게시글 입니다.", exception.getMessage());
+    }
+
+    @Test
+    void failedSearchPostDetail() {
+        //given
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(PostDoesNotExistException.class,
+                () -> postService.searchPostDetail(1L));
+        //then
+        assertEquals("존재하지 않는 게시글 입니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## key Changes 🤩

- ### CommentController:
    -  /comment/create 엔드포인트를 통한 댓글 작성 기능 추가.
    -  /comment/create/reply 엔드포인트를 통한 대댓글 작성 기능 추가.
    -  /comment/update/{id} 엔드포인트를 통한 댓글 수정 기능 추가.
    -  /comment/delete/{id} 엔드포인트를 통한 댓글 삭제 기능 추가.
    -  /comment/search 엔드포인트를 통한 부모 댓글들 조회 기능 추가.
    -  /comment/search/reply 엔드포인트를 통한 한 부모 댓글의 대댓글(답글)들 조회 기능 추가.

- ### Comment 엔티티:
    -  comment 엔티티에 필요한 필드 및 연관 관계 추가.

-  ### CommentService:
    -  댓글/대댓글(답글) 생성, 업데이트, 삭제, 조회 기능 구현.
    -  예외 처리를 통한 안정성 보완.
    
-  ### DTO:
    -  CommentRequest: 댓글/대댓글(답글) 생성/수정 요청을 위한 DTO.
    -  CommentInfoResponse: 댓글 정보를 반환하는 DTO.
    -  ReplyInfoResponse: 대댓글(답글) 정보를 반환하는 DTO.

- ### 예외처리
    -  CommentExceptionHandler 클래스 추가:
        -  CannotCreateCommentException, CommentDoesNotExistException을 처리하는 핸들러를 포함합니다.
        -  CommentDoesNotExistException이 발생하면 HTTP 상태 코드 404 (Not Found)와 에러 메시지를 반환합니다.
    -  CommentDoesNotExistException 클래스 추가:
        -  댓글이 존재하지 않을 때 던지는 예외입니다.
        - 예외 메시지로 COMMENT_NOT_FOUND 에러 코드의 설명을 사용합니다.
    -  CannotCreateCommentException 클래스 추가:
        -   댓글 및 답글을 작성할 수 없을 때 던지는 예외입니다.
        -   IMPOSSIBLE_CREATE_COMMENT 에러 코드의 설명을 사용합니다.


