### PR TITLE
feat: post memberId로 조회 기능 추가

### DIFF
--- a/src/main/java/com/be/inssagram/domain/post/controller/PostController.java
+++ b/src/main/java/com/be/inssagram/domain/post/controller/PostController.java
@@ -51,4 +51,12 @@ public class PostController {
         return ApiResponse.createSuccess(postService.searchPostAll());
     }
 
+    @GetMapping("")
+    public ApiResponse<List<PostInfoResponse>> searchPostWithMemberId(
+            @RequestParam(value = "member-id") Long memberId
+    ) {
+        return ApiResponse.createSuccess(
+                postService.searchPostWithMember(memberId));
+    }
+
 }

--- a/src/main/java/com/be/inssagram/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/be/inssagram/domain/post/repository/PostRepository.java
@@ -4,7 +4,9 @@ import com.be.inssagram.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-
+    List<Post> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/be/inssagram/domain/post/service/PostService.java
+++ b/src/main/java/com/be/inssagram/domain/post/service/PostService.java
@@ -88,8 +88,7 @@ public class PostService {
 
         List<Post> posts = postRepository.findByMemberId(memberId);
 
-        return posts.stream()
-                .map(PostInfoResponse::from).toList();
+        return getPostInfoResponsesWithLikeInfo(posts);
     }
 
     private List<PostInfoResponse> getPostInfoResponsesWithLikeInfo(List<Post> posts) {


### PR DESCRIPTION
## key Changes 🤩

- ### PostController:
    -  /post?member-id={Long memberId} 엔드포인트를 통한 특정 멤버가 작성한 포스트 조회 기능 추가.

-  ### PostService:
    -  멤버 아이디로 포스트 조회 기능 추가
   
-  ### PostRepository:
    -   List<Post> findByMemberId(Long memberId) 함수 추가
    
-  ### getPostInfoResponsesWithLikeInfo:
    -  조회 시 like 정보(좋아요한 사람 수와 좋아요 수) PostInfoResponse에 넣어주는 함수.