### PR TITLE
Feature/#6 hashtag

### DIFF
--- a/src/main/java/com/be/inssagram/domain/hashTag/controller/HashTagController.java
+++ b/src/main/java/com/be/inssagram/domain/hashTag/controller/HashTagController.java
@@ -1,0 +1,25 @@
+package com.be.inssagram.domain.hashTag.controller;
+
+import com.be.inssagram.common.ApiResponse;
+import com.be.inssagram.domain.hashTag.service.HashTagService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class HashTagController {
+
+    private final HashTagService hashTagService;
+
+    @GetMapping("/hashTag-post-list")
+    public ApiResponse<?> searchPostWithHashTagName(
+            @RequestParam(value = "hashtag-name") String name
+    ) {
+        return ApiResponse.createSuccess(hashTagService
+                .searchPostWithHashTagName(name));
+    }
+}

--- a/src/main/java/com/be/inssagram/domain/hashTag/dto/request/HashTagRequest.java
+++ b/src/main/java/com/be/inssagram/domain/hashTag/dto/request/HashTagRequest.java
@@ -1,0 +1,14 @@
+package com.be.inssagram.domain.hashTag.dto.request;
+
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HashTagRequest {
+    private String name;
+
+}

--- a/src/main/java/com/be/inssagram/domain/hashTag/entity/HashTag.java
+++ b/src/main/java/com/be/inssagram/domain/hashTag/entity/HashTag.java
@@ -1,0 +1,21 @@
+package com.be.inssagram.domain.hashTag.entity;
+
+import com.be.inssagram.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "HASHTAG")
+public class HashTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private Post post;
+    private String name;
+
+}

--- a/src/main/java/com/be/inssagram/domain/hashTag/repository/HashTagRepository.java
+++ b/src/main/java/com/be/inssagram/domain/hashTag/repository/HashTagRepository.java
@@ -1,0 +1,18 @@
+package com.be.inssagram.domain.hashTag.repository;
+
+import com.be.inssagram.domain.hashTag.entity.HashTag;
+import com.be.inssagram.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+    List<HashTag> findByName(String name);
+
+    List<HashTag> findByPost(Post post);
+
+    HashTag findByPostAndName(Post post, String name);
+
+}

--- a/src/main/java/com/be/inssagram/domain/hashTag/service/HashTagService.java
+++ b/src/main/java/com/be/inssagram/domain/hashTag/service/HashTagService.java
@@ -1,0 +1,37 @@
+package com.be.inssagram.domain.hashTag.service;
+
+import com.be.inssagram.domain.hashTag.entity.HashTag;
+import com.be.inssagram.domain.hashTag.repository.HashTagRepository;
+import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
+import com.be.inssagram.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HashTagService {
+
+    private final HashTagRepository hashTagRepository;
+
+    public void saveHashTag(Post post, String name) {
+
+        if (hashTagRepository.findByPostAndName(post, name) == null) {
+            HashTag hashTag = HashTag.builder()
+                    .name(name)
+                    .post(post)
+                    .build();
+            hashTagRepository.save(hashTag);
+        }
+    }
+
+    public List<PostInfoResponse> searchPostWithHashTagName(String name) {
+        List<HashTag> hashTagList = hashTagRepository.findByName(name);
+        System.out.println(hashTagList.size());
+        return hashTagList.stream().map(HashTag::getPost)
+                .map(PostInfoResponse::from).toList();
+    }
+
+
+}

--- a/src/main/java/com/be/inssagram/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/request/CreatePostRequest.java
@@ -16,9 +16,7 @@ public class CreatePostRequest {
     private List<String> image;
     private String contents;
     private String location;
-//    private Set<Long> taggedMemberIds; // TaggedMember 엔티티의 ID 목록
     private Set<String> taggedMembers; // TaggedMember 목록
-//    private Set<Long> hashTagIds; // HashTag 엔티티의 ID 목록
-    private Set<String> hashTags; // HashTag 목록
+    private List<String> hashTags; // HashTag 목록
 
 }

--- a/src/main/java/com/be/inssagram/domain/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/request/UpdatePostRequest.java
@@ -3,6 +3,7 @@ package com.be.inssagram.domain.post.dto.request;
 
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
 
 @Setter
@@ -15,6 +16,6 @@ public class UpdatePostRequest {
     private String contents;
     private String location;
     private Set<String> taggedMembers;
-    private Set<String> hashTags;
+    private List<String> hashTags;
 
 }

--- a/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
+++ b/src/main/java/com/be/inssagram/domain/post/dto/response/PostInfoResponse.java
@@ -25,7 +25,7 @@ public class PostInfoResponse {
     private Integer likeCount;
     private Integer commentsCounts;
     private Set<String> taggedMembers;
-    private Set<String> hashTags;
+    private List<String> hashTags;
 
     public static PostInfoResponse from(Post post) {
         int commentCounts = 0;
@@ -41,7 +41,6 @@ public class PostInfoResponse {
 //                .comments(post.getComments())
                 .commentsCounts(commentCounts)
                 .taggedMembers(post.getTaggedMembers())
-                .hashTags(post.getHashTags())
                 .build();
     }
 

--- a/src/main/java/com/be/inssagram/domain/post/entity/Post.java
+++ b/src/main/java/com/be/inssagram/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.be.inssagram.domain.post.entity;
 
 import com.be.inssagram.common.BaseEntity;
 import com.be.inssagram.domain.comment.entity.Comment;
+import com.be.inssagram.domain.hashTag.entity.HashTag;
 import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
@@ -39,16 +40,9 @@ public class Post extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
     @ElementCollection
     private Set<String> taggedMembers;
-    @ElementCollection
-    private Set<String> hashTags;
-
 
     public void setTaggedMembers(Set taggedMembers) {
         this.taggedMembers = taggedMembers;
-    }
-
-    public void setHashTags(Set hashTags) {
-        this.hashTags = hashTags;
     }
 
     public void updateFields(UpdatePostRequest request) {
@@ -61,9 +55,7 @@ public class Post extends BaseEntity {
         if (request.getTaggedMembers() != null) {
             taggedMembers = request.getTaggedMembers();
         }
-        if (request.getHashTags() != null) {
-            hashTags = request.getHashTags();
-        }
+
     }
 
 }

--- a/src/test/java/com/be/inssagram/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/be/inssagram/domain/post/controller/PostControllerTest.java
@@ -53,7 +53,7 @@ class PostControllerTest {
                 .likeCount(1)
                 .location("home")
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
+                .hashTags(new ArrayList<>())
                 .build());
         //when
         //then
@@ -66,7 +66,7 @@ class PostControllerTest {
                                         .contents("AAA")
                                         .location("sweet")
                                         .taggedMembers(new HashSet<>())
-                                        .hashTags(new HashSet<>())
+                                        .hashTags(new ArrayList<>())
                                         .build()))
                 ).andDo(print())
                 .andExpect(status().isOk())
@@ -87,7 +87,7 @@ class PostControllerTest {
                         .likeCount(1)
                         .location("home")
                         .taggedMembers(new HashSet<>())
-                        .hashTags(new HashSet<>())
+                        .hashTags(new ArrayList<>())
                         .build());
         //when
         //then
@@ -98,7 +98,7 @@ class PostControllerTest {
                                 .contents("AAA")
                                 .location("sweet")
                                 .taggedMembers(new HashSet<>())
-                                .hashTags(new HashSet<>())
+                                .hashTags(new ArrayList<>())
                                 .build()))
                 ).andDo(print())
                 .andExpect(status().isOk())
@@ -136,7 +136,7 @@ class PostControllerTest {
                         .likeCount(1)
                         .location("home")
                         .taggedMembers(new HashSet<>())
-                        .hashTags(new HashSet<>())
+                        .hashTags(new ArrayList<>())
                         .build());
         //when
         //then
@@ -165,7 +165,7 @@ class PostControllerTest {
                         .likeCount(1)
                         .location("home")
                         .taggedMembers(new HashSet<>())
-                        .hashTags(new HashSet<>())
+                        .hashTags(new ArrayList<>())
                         .build());
         given(postService.searchPostAll())
                 .willReturn(postInfoResponseList);
@@ -178,7 +178,7 @@ class PostControllerTest {
                 .andDo(print())
                 .andExpect(jsonPath("$.status")
                         .value("success"))
-                .andExpect(jsonPath("$.data.content[0].memberId")
+                .andExpect(jsonPath("$.data[0].memberId")
                         .value(1L))
         ;
     }

--- a/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
@@ -1,5 +1,6 @@
 package com.be.inssagram.domain.post.service;
 
+import com.be.inssagram.domain.hashTag.repository.HashTagRepository;
 import com.be.inssagram.domain.like.entity.Like;
 import com.be.inssagram.domain.like.repository.LikeRepository;
 import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
@@ -37,6 +38,8 @@ class PostServiceTest {
 
     @Mock
     private LikeRepository likeRepository;
+    @Mock
+    private HashTagRepository hashTagRepository;
 
     @InjectMocks
     private PostService postService;
@@ -89,6 +92,7 @@ class PostServiceTest {
                 .taggedMembers(new HashSet<>())
                 .hashTags(new ArrayList<>())
                 .build());
+        updateResponse.setHashTags(new ArrayList<>());
         //then
         assertEquals(1L, updateResponse.getMemberId());
         assertEquals("AAA", updateResponse.getContents());
@@ -128,9 +132,12 @@ class PostServiceTest {
                 .taggedMembers(new HashSet<>())
                 .build();
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+
         //when
         PostInfoResponse searchResponse = postService.searchPostDetail(1L);
+
         searchResponse.setLikeCount(0);
+        searchResponse.setHashTags(new ArrayList<>());
         //then
         assertEquals(1L, searchResponse.getMemberId());
     }

--- a/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/be/inssagram/domain/post/service/PostServiceTest.java
@@ -1,5 +1,7 @@
 package com.be.inssagram.domain.post.service;
 
+import com.be.inssagram.domain.like.entity.Like;
+import com.be.inssagram.domain.like.repository.LikeRepository;
 import com.be.inssagram.domain.post.dto.request.CreatePostRequest;
 import com.be.inssagram.domain.post.dto.request.UpdatePostRequest;
 import com.be.inssagram.domain.post.dto.response.PostInfoResponse;
@@ -33,6 +35,9 @@ class PostServiceTest {
     @Mock
     private PostRepository postRepository;
 
+    @Mock
+    private LikeRepository likeRepository;
+
     @InjectMocks
     private PostService postService;
 
@@ -47,7 +52,6 @@ class PostServiceTest {
                 .location("home")
                 .comments(new ArrayList<>())
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
                 .build();
         given(postRepository.save(any())).willReturn(post);
         //when
@@ -58,7 +62,7 @@ class PostServiceTest {
                 .contents("AAA")
                 .location("sweet")
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
+                .hashTags(new ArrayList<>())
                 .build());
         //then
         assertEquals(1L, createResponse.getMemberId());
@@ -75,7 +79,6 @@ class PostServiceTest {
                 .location("home")
                 .comments(new ArrayList<>())
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
                 .build();
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
         //when
@@ -84,7 +87,7 @@ class PostServiceTest {
                 .contents("AAA")
                 .location("sweet")
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
+                .hashTags(new ArrayList<>())
                 .build());
         //then
         assertEquals(1L, updateResponse.getMemberId());
@@ -102,7 +105,6 @@ class PostServiceTest {
                 .location("home")
                 .comments(new ArrayList<>())
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
                 .build();
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
         ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
@@ -124,11 +126,11 @@ class PostServiceTest {
                 .location("home")
                 .comments(new ArrayList<>())
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
                 .build();
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
         //when
         PostInfoResponse searchResponse = postService.searchPostDetail(1L);
+        searchResponse.setLikeCount(0);
         //then
         assertEquals(1L, searchResponse.getMemberId());
     }
@@ -144,13 +146,10 @@ class PostServiceTest {
                 .location("home")
                 .comments(new ArrayList<>())
                 .taggedMembers(new HashSet<>())
-                .hashTags(new HashSet<>())
                 .build();
         List<Post> list = Collections.singletonList(post);
-        Page<Post> page = new PageImpl<>(list);
-        given(postRepository.findAll((Pageable) any())).willReturn(page);
+        given(postRepository.findAll()).willReturn(list);
         //when
-        Pageable pageable = PageRequest.of(0, 3);
         List<PostInfoResponse> responses = postService.searchPostAll();
         //then
         assertEquals(1L, responses.get(0).getPostId());
@@ -168,7 +167,7 @@ class PostServiceTest {
                         .contents("AAA")
                         .location("sweet")
                         .taggedMembers(new HashSet<>())
-                        .hashTags(new HashSet<>())
+                        .hashTags(new ArrayList<>())
                         .build()));
         //then
         assertEquals("존재하지 않는 게시글 입니다.", exception.getMessage());


### PR DESCRIPTION
**PR 요약**

이 PR은 해시태그 관련 기능을 추가하고 있으며, 다음과 같은 주요 변경 사항을 포함합니다:

- 해시태그 엔티티 추가
- 해시태그 이름으로 게시물을 검색하기 위한 엔드포인트 추가
- 데이터베이스 상호작용을 위한 리포지토리 및 서비스 구현
- 게시물과 해시태그 이름을 입력하여 해시태그 저장

**변경 내용**

- `HashTag` 엔티티를 JPA 어노테이션을 사용하여 정의하였습니다.
- `HashTagController`를 구현하여 해시태그 이름으로 게시물을 검색할 수 있는 GET 엔드포인트를 추가하였습니다.
- `HashTagRepository`를 구현하여 해시태그 이름으로 검색하거나 게시물과 해시태그 이름으로 해시태그를 검색할 수 있도록 하였습니다.
- `HashTagService`를 구현하여 게시물과 해시태그 이름을 입력받아 해시태그를 저장하도록 하였습니다.
